### PR TITLE
[dir_bcast] Replace injected BOOTP UDP packet with ordinary IP packet

### DIFF
--- a/ansible/roles/test/files/ptftests/dir_bcast_test.py
+++ b/ansible/roles/test/files/ptftests/dir_bcast_test.py
@@ -38,7 +38,7 @@ class BcastTest(BaseTest):
     # Class variables
     #---------------------------------------------------------------------
     BROADCAST_MAC = 'ff:ff:ff:ff:ff:ff'
-    TEST_SRC_IP = "10.0.0.100"  # Some src IP
+    TEST_SRC_IP = "1.1.1.1"  # Some src IP
 
     def __init__(self):
         '''


### PR DESCRIPTION
If DHCP relay server is configured, the injected packet would be
forwarded to the DHCP servers. Replace the injected BOOTP UDP packet
with ordinary IP packet to ensure that it is broadcasted to all
interfaces of the VLAN.

Signed-off-by: Xin Wang <xinw@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

If DHCP relay server is configured, the injected BOOTP packet would be unicast to the configured DHCP servers and this test case would fail. Replace the injected BOOTP packet with an ordinary IP packet. Then it will be broadcast to all the VLAN interfaces.

### Type of change

- [*] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Replace the injected BOOTP packet with an ordinary IP packet.

#### How did you verify/test it?
Tested on Mellanox platform running t0 topology. Used the latest image from master branch.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
