### PR TITLE
[ptf_runner] Save ptf log to script executing host in case of failure

### DIFF
--- a/ansible/roles/test/tasks/ptf_runner.yml
+++ b/ansible/roles/test/tasks/ptf_runner.yml
@@ -74,13 +74,13 @@
     - "{{ ptf_log_file }}"
     - "{{ ptf_pcap_file }}"
   delegate_to: "{{ ptf_host }}"
-  when: out.rc != 0
+  when: out.rc != 0 and save_ptf_log is defined and save_ptf_log|bool == true
 
 - debug: msg="File {{ item }} saved to test/{{ inventory_hostname }}/ptf/"
   with_items:
     - "{{ptf_log_file}}"
     - "{{ptf_pcap_file}}"
-  when: out.rc != 0
+  when: out.rc != 0 and save_ptf_log is defined and save_ptf_log|bool == true
 
 - fail: msg="Failed test '{{ ptf_test_name }}'"
   when: out.rc != 0

--- a/ansible/roles/test/tasks/ptf_runner.yml
+++ b/ansible/roles/test/tasks/ptf_runner.yml
@@ -51,5 +51,36 @@
 
 - debug: var=out.stdout_lines
 
+- name: Set default PTF log filename
+  set_fact:
+    ptf_log_file: "/root/ptf.log"
+    ptf_log_file_param_index: "{{ out.cmd.find('--log-file') }}"
+
+- name: Parse custom log filename specified in PTF command
+  set_fact:
+    ptf_log_file: "{{ out.cmd[ptf_log_file_param_index|int:].split(' ')[1] }}"
+  when: ptf_log_file_param_index|int >= 0
+
+- name: Set PTF pcap filename
+  set_fact:
+    ptf_pcap_file: "{{ ptf_log_file | replace('.log', '.pcap') }}"
+
+- name : Fetch result files from switch to ansible machine
+  fetch:
+    src: "{{ item }}"
+    dest: "test/{{ inventory_hostname }}/ptf/{{ item | basename }}.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}"
+    flat: yes
+  with_items:
+    - "{{ ptf_log_file }}"
+    - "{{ ptf_pcap_file }}"
+  delegate_to: "{{ ptf_host }}"
+  when: out.rc != 0
+
+- debug: msg="File {{ item }} saved to test/{{ inventory_hostname }}/ptf/"
+  with_items:
+    - "{{ptf_log_file}}"
+    - "{{ptf_pcap_file}}"
+  when: out.rc != 0
+
 - fail: msg="Failed test '{{ ptf_test_name }}'"
   when: out.rc != 0


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

The PTF log and pcap files are useful for debugging in case of PTF
script failed. However, these files are in the PTF container and could
be lost when the PTF container is re-deployed.

This improvement is to save the log and pcap files to the script
executing host when the PTF script is failed.

### Type of change

- [] Bug fix
- [x] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
When the PTF script failed, copy the PTF log and pcap files to sonic-mgmt container for later debugging.

#### How did you verify/test it?
Tested on Mellanox platform.

#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
