### PR TITLE
Improve the platform SFP testing

### DIFF
--- a/tests/platform/platform_fixtures.py
+++ b/tests/platform/platform_fixtures.py
@@ -1,4 +1,5 @@
 import pytest
+import os
 
 @pytest.fixture(scope="module")
 def conn_graph_facts(testbed_devices):

--- a/tests/platform/test_sfp.py
+++ b/tests/platform/test_sfp.py
@@ -97,7 +97,8 @@ def test_check_sfp_status_and_configure_sfp(testbed_devices, conn_graph_facts):
     for intf in conn_graph_facts["device_conn"]:
         reset_result = ans_host.command("%s %s" % (cmd_sfp_reset, intf))
         assert reset_result["rc"] == 0, "'%s %s' failed" % (cmd_sfp_reset, intf)
-    time.sleep(120)  # Wait some time for SFP to fully recover after reset
+        time.sleep(5)
+    time.sleep(60)  # Wait some time for SFP to fully recover after reset
 
     logging.info("Check sfp presence again after reset")
     sfp_presence = ans_host.command(cmd_sfp_presence)
@@ -105,6 +106,12 @@ def test_check_sfp_status_and_configure_sfp(testbed_devices, conn_graph_facts):
     for intf in conn_graph_facts["device_conn"]:
         assert intf in parsed_presence, "Interface is not in output of '%s'" % cmd_sfp_presence
         assert parsed_presence[intf] == "Present", "Interface presence is not 'Present'"
+
+    logging.info("Check interface status")
+    mg_facts = ans_host.minigraph_facts(host=ans_host.hostname)["ansible_facts"]
+    intf_facts = ans_host.interface_facts(up_ports=mg_facts["minigraph_ports"])["ansible_facts"]
+    assert len(intf_facts["ansible_interface_link_down_ports"]) == 0, \
+        "Some interfaces are down: %s" % str(intf_facts["ansible_interface_link_down_ports"])
 
 
 def test_check_sfp_low_power_mode(testbed_devices, conn_graph_facts):
@@ -164,3 +171,9 @@ def test_check_sfp_low_power_mode(testbed_devices, conn_graph_facts):
     for intf in conn_graph_facts["device_conn"]:
         assert intf in parsed_presence, "Interface is not in output of '%s'" % cmd_sfp_presence
         assert parsed_presence[intf] == "Present", "Interface presence is not 'Present'"
+
+    logging.info("Check interface status")
+    mg_facts = ans_host.minigraph_facts(host=ans_host.hostname)["ansible_facts"]
+    intf_facts = ans_host.interface_facts(up_ports=mg_facts["minigraph_ports"])["ansible_facts"]
+    assert len(intf_facts["ansible_interface_link_down_ports"]) == 0, \
+        "Some interfaces are down: %s" % str(intf_facts["ansible_interface_link_down_ports"])

--- a/tests/platform/test_sfp.py
+++ b/tests/platform/test_sfp.py
@@ -98,7 +98,8 @@ def test_check_sfp_status_and_configure_sfp(testbed_devices, conn_graph_facts):
         reset_result = ans_host.command("%s %s" % (cmd_sfp_reset, intf))
         assert reset_result["rc"] == 0, "'%s %s' failed" % (cmd_sfp_reset, intf)
         time.sleep(5)
-    time.sleep(60)  # Wait some time for SFP to fully recover after reset
+    logging.info("Wait some time for SFP to fully recover after reset")
+    time.sleep(60)
 
     logging.info("Check sfp presence again after reset")
     sfp_presence = ans_host.command(cmd_sfp_presence)


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Improve the platform SFP testing.

* Add interface status check after tested lpmode
* Add delay between SFP reset operation. If there is port spliting,
same SFP module may be reset multiple times. Increase delay for
SFP module reset operation to complete. The overall delay after
all reset operations can be decreased.
* Add interface status check after tested SFP reset
* Add "import os" missed in platform_fixtures.py

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?
Tested on Mellanox platform.

#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?
NA

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
