### PR TITLE
[interface.yml] Raise the failures again in the rescue blocks

### DIFF
--- a/ansible/roles/test/tasks/interface.yml
+++ b/ansible/roles/test/tasks/interface.yml
@@ -35,11 +35,13 @@
 - block:
   - name: Verify interfaces are up correctly
     assert: { that: "{{ ansible_interface_link_down_ports | length }} == 0" }
+
   rescue:
   - include_tasks: check_fanout_interfaces.yml
     vars:
       check_fanout: true
-  - debug: msg="Not all Interfaces are up"
+
+  - fail: msg="Not all interfaces are up"
 
 - block:
   - name: Verify port channel interfaces are up correctly
@@ -50,8 +52,11 @@
   - include_tasks: check_sw_vm_interfaces.yml
     vars:
       check_vms: true
-  - debug: msg="Not all PortChannels are up '{{ portchannel_status['stdout_lines'] }}' "
+
+  - debug: msg="PortChannel status '{{ portchannel_status['stdout_lines'] }}'"
     when: portchannel_status is defined
+
+  - fail: msg="Not all PortChannels are up"
 
 - name: Verify VLAN interfaces are up correctly
   assert: { that: "'{{ ansible_interface_facts[item]['active'] }}' == 'True'" }


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #1244

In the ansible/roles/test/tasks/interface.yml script, there are some logics to do further checking for debugging purpose in case of PortChannels or Interfaces are down.

The problem is caused by the "rescue" blocks. According to ansible documentation https://docs.ansible.com/ansible/latest/user_guide/playbooks_blocks.html:

"This will ‘revert’ the failed status of the task for the run and the play will continue as if it had succeeded."

The consequence is that ansible testing playbooks using this interface.yml file will not be failed as expected when PortChannels or interfaces are down because the failures have been rescued.

The fix is to raise the failures again in the rescue blocks.

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Raise the failures again in the rescue blocks.

#### How did you verify/test it?
Tested on Mellanox platform.

#### Any platform specific information?
None

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
