### PR TITLE
Fix the issue of reading vars_file 'vars/docker_registry.yml' for each task

### DIFF
--- a/ansible/roles/test/tasks/sonic.yml
+++ b/ansible/roles/test/tasks/sonic.yml
@@ -1,3 +1,5 @@
+- include_vars: "vars/docker_registry.yml"
+
 - include_vars: "roles/test/vars/testcases.yml"
 
 - name: Gathering minigraph facts about the device

--- a/ansible/test_sonic.yml
+++ b/ansible/test_sonic.yml
@@ -14,8 +14,6 @@
 
 
 - hosts: sonic
-  vars_files:
-    - vars/docker_registry.yml
   roles:
     - { role: test, scope: 'sonic' }
   force_handlers: true


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #1307

According to log of ansible playbook test cases, each task reads vars_file 'vars/docker_registry.yml'.
This PR fix this issue.

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
* Remove the 'vars_files' statement in test_sonic.yml
* Read the vars using include_vars in sonic.yml

#### How did you verify/test it?
Test run a few ansible playbook cases.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
